### PR TITLE
無効なURLを含むリンクがパースできない問題を修正

### DIFF
--- a/lib/src/internal/language.dart
+++ b/lib/src/internal/language.dart
@@ -632,6 +632,15 @@ class Language {
           state.linkLabel = false;
           return result;
         });
+        final urlNoFallback = Parser(
+          handler: (input, index, state) {
+            final result = url.handler(input, index, state);
+            if (result.value is MfmURL) {
+              return result;
+            }
+            return failure();
+          },
+        );
         final closeLabel = str(']');
         return seq([
           notLinkLabel,
@@ -643,7 +652,7 @@ class Language {
               .many(1),
           closeLabel,
           str('('),
-          alt([urlAlt, url]),
+          alt([urlAlt, urlNoFallback]),
           str(')'),
         ]).map((result) {
           final silent = (result[1] == '?[');

--- a/test/mfm_test.dart
+++ b/test/mfm_test.dart
@@ -1158,6 +1158,12 @@ hoge""";
         ];
         expect(parse(input), orderedEquals(output));
       });
+
+      test('bad url in url part', () {
+        const input = "[test](http://..)";
+        final output = [MfmText("[test](http://..)")];
+        expect(parse(input), orderedEquals(output));
+      });
     });
 
     group("fn", () {


### PR DESCRIPTION
リンクの中のURLのスキーマ以下の部分がすべて `.` か `,` のときにパースに失敗する問題を修正しました

ref: `https://github.com/misskey-dev/mfm.js/pull/142`