### PR TITLE
allow period in mention

### DIFF
--- a/lib/src/internal/language.dart
+++ b/lib/src/internal/language.dart
@@ -505,7 +505,7 @@ class Language {
         final parser = seq([
           notLinkLabel,
           str("@"),
-          regexp(RegExp(r"[a-zA-Z0-9_-]+")),
+          regexp(RegExp(r"[a-zA-Z0-9_.-]+")),
           seq([
             str("@"),
             regexp(RegExp(r"[a-zA-Z0-9_.-]+")),
@@ -537,9 +537,9 @@ class Language {
               }
             }
           }
-          // remove "-" of tail of username
+          // remove [.-] of tail of username
           String modifiedName = username;
-          final regResult2 = RegExp(r"-+$").firstMatch(username);
+          final regResult2 = RegExp(r"[.-]+$").firstMatch(username);
           if (regResult2 != null) {
             if (modifiedHost == null) {
               modifiedName = username.slice(0, (-1 * regResult2[0]!.length));
@@ -548,8 +548,8 @@ class Language {
               invalidMention = true;
             }
           }
-          // disallow "-" of head of username
-          if (modifiedName.isEmpty || modifiedName[0] == '-') {
+          // disallow [.-] of head of username
+          if (modifiedName.isEmpty || RegExp(r"^[.-]").hasMatch(modifiedName)) {
             invalidMention = true;
           }
           // disallow [.-] of head of hostname

--- a/test/mfm_test.dart
+++ b/test/mfm_test.dart
@@ -710,13 +710,31 @@ hoge""";
         expect(parse(input), orderedEquals(output));
       });
 
+      test("allow `.` in middle of username", () {
+        final input = "@a.bc";
+        final output = [MfmMention("a.bc", null, "@a.bc")];
+        expect(parse(input), orderedEquals(output));
+      });
+
       test("disallow `.` in head of username", () {
+        final input = "@.abc";
+        final output = [MfmText("@.abc")];
+        expect(parse(input), orderedEquals(output));
+      });
+
+      test("disallow `.` in tail of username", () {
+        final input = "@abc.";
+        final output = [MfmMention("abc", null, "@abc"), MfmText(".")];
+        expect(parse(input), orderedEquals(output));
+      });
+
+      test("disallow `.` in head of hostname", () {
         final input = "@abc@.aaa";
         final output = [MfmText("@abc@.aaa")];
         expect(parse(input), orderedEquals(output));
       });
 
-      test("disallow `.` in tail of username", () {
+      test("disallow `.` in tail of hostname", () {
         final input = "@abc@aaa.";
         final output = [MfmMention("abc", "aaa", "@abc@aaa"), MfmText(".")];
         expect(parse(input), orderedEquals(output));


### PR DESCRIPTION
メンションのユーザーネームの中にピリオドを含むことができるようにしました

ref: [misskey-dev/mfm.js#150](https://redirect.github.com/misskey-dev/mfm.js/pull/150)

Fix shiosyakeyakini-info/miria#161