### PR TITLE
VS16をテキストとして返す

### DIFF
--- a/lib/src/internal/language.dart
+++ b/lib/src/internal/language.dart
@@ -386,8 +386,9 @@ class Language {
         });
       },
       "unicodeEmoji": () {
-        return regexp(tweEmojiParser)
-            .map((content) => MfmUnicodeEmoji(content));
+        return regexp(tweEmojiParser).map(
+          (content) => content == "\uFE0F" ? content : MfmUnicodeEmoji(content),
+        );
       },
       "emojiCode": () {
         final side = notMatch(regexp(RegExp(r"[a-zA-Z0-9]")));

--- a/test/mfm_test.dart
+++ b/test/mfm_test.dart
@@ -50,6 +50,12 @@ void main() {
         final output = [MfmText("あ"), MfmEmojiCode("bar"), MfmText("い")];
         expect(MfmParser().parseSimple(input), orderedEquals(output));
       });
+
+      test("ignore variation selecter", () {
+        const input = "\uFE0F";
+        final output = [MfmText("\uFE0F")];
+        expect(MfmParser().parseSimple(input), orderedEquals(output));
+      });
     });
 
     test("disallow other syntaxes", () {


### PR DESCRIPTION
\uFE0Fが単体でUnicode絵文字の正規表現に引っかかったときに絵文字ではなくテキストとして解釈するようにしました

ref: [misskey-dev/mfm.js#137](https://redirect.github.com/misskey-dev/mfm.js/pull/137)